### PR TITLE
add ha core api support

### DIFF
--- a/src/Libs/HomeAssistant.ts
+++ b/src/Libs/HomeAssistant.ts
@@ -8,8 +8,6 @@ export interface IHomeAssistant {
 }
 
 export default class HomeAssistant implements IHomeAssistant {
-    private readonly supervisorToken: string | undefined = process.env.SUPERVISOR_TOKEN
-
     public constructor (
         private readonly logger: ILogger,
         private readonly eventBus: IEventBus,
@@ -19,7 +17,7 @@ export default class HomeAssistant implements IHomeAssistant {
     }
 
     public start (): void {
-        if (this.supervisorToken === undefined) {
+        if (process.env.SUPERVISOR_TOKEN === undefined) {
             this.logger.warn('Home Assistant integration disabled')
             return
         }
@@ -70,6 +68,6 @@ export default class HomeAssistant implements IHomeAssistant {
     }
 
     private async sendToHomeAssistant (event: string, data: any): Promise<void> {
-        await this.eventPublisher.publish('whatsapp_' + event, data, this.supervisorToken as string)
+        await this.eventPublisher.publish('whatsapp_' + event, data)
     }
 }

--- a/src/container.ts
+++ b/src/container.ts
@@ -27,6 +27,8 @@ export interface IServices {
 
 const webConfig = getHttpServer()
 const whatsappClient = getWhatsappClient()
+const haToken = process.env.SUPERVISOR_TOKEN
+const haBaseUrl = process.env.HA_BASE_URL
 
 export default diContainer<IServices>({
     app: () =>
@@ -54,7 +56,7 @@ export default diContainer<IServices>({
         new MediaUrlMessageCreator(whatsapp),
 
     haEventPublisher: ({ logger }) =>
-        new EventPublisher(logger),
+        new EventPublisher(logger, haToken, haBaseUrl),
 
     homeAssistant: ({ logger, eventBus, haEventPublisher }) =>
         new HomeAssistant(logger, eventBus, haEventPublisher)

--- a/tests/Libs/HomeAssistant.test.ts
+++ b/tests/Libs/HomeAssistant.test.ts
@@ -40,7 +40,7 @@ describe('Home assistant', () => {
         await onMessage({ message: { id: 'id', rawData: { id: 'id' } } })
 
         expect(mockLogger.info).toHaveBeenCalledWith('onMessage', 'id')
-        expect(mockEventPublisher.publish).toHaveBeenCalledWith('whatsapp_message_received', { id: 'id' }, 'token')
+        expect(mockEventPublisher.publish).toHaveBeenCalledWith('whatsapp_message_received', { id: 'id' })
     })
 
     it('onCreatedMessage', async () => {
@@ -53,7 +53,7 @@ describe('Home assistant', () => {
         await onCreatedMessage({ message: { id: 'id', rawData: { id: 'id' } } })
 
         expect(mockLogger.info).toHaveBeenCalledWith('onCreatedMessage', 'id')
-        expect(mockEventPublisher.publish).toHaveBeenCalledWith('whatsapp_message_sent', { id: 'id' }, 'token')
+        expect(mockEventPublisher.publish).toHaveBeenCalledWith('whatsapp_message_sent', { id: 'id' })
     })
 
     it('onMessageAck', async () => {
@@ -68,7 +68,7 @@ describe('Home assistant', () => {
         const event = { message: { id: 'id' }, ack: 1 }
 
         expect(mockLogger.info).toHaveBeenCalledWith('onMessageAck', event)
-        expect(mockEventPublisher.publish).toHaveBeenCalledWith('whatsapp_message_ack', event, 'token')
+        expect(mockEventPublisher.publish).toHaveBeenCalledWith('whatsapp_message_ack', event)
     })
 
     it('onState', async () => {
@@ -82,7 +82,7 @@ describe('Home assistant', () => {
         await onState(event)
 
         expect(mockLogger.info).toHaveBeenCalledWith('onChangedState', event)
-        expect(mockEventPublisher.publish).toHaveBeenCalledWith('whatsapp_state', event, 'token')
+        expect(mockEventPublisher.publish).toHaveBeenCalledWith('whatsapp_state', event)
     })
 
     it('onAuthenticated', async () => {
@@ -94,7 +94,7 @@ describe('Home assistant', () => {
         await onAuthenticated()
 
         expect(mockLogger.info).toHaveBeenCalledWith('onAuthenticated')
-        expect(mockEventPublisher.publish).toHaveBeenCalledWith('whatsapp_authenticated', {}, 'token')
+        expect(mockEventPublisher.publish).toHaveBeenCalledWith('whatsapp_authenticated', {})
     })
 
     it('onDisconnected', async () => {
@@ -106,6 +106,6 @@ describe('Home assistant', () => {
         await onDisconnected()
 
         expect(mockLogger.info).toHaveBeenCalledWith('onDisconnected')
-        expect(mockEventPublisher.publish).toHaveBeenCalledWith('whatsapp_disconnected', {}, 'token')
+        expect(mockEventPublisher.publish).toHaveBeenCalledWith('whatsapp_disconnected', {})
     })
 })

--- a/tests/Services/HomeAssistant/EventPublisher.test.ts
+++ b/tests/Services/HomeAssistant/EventPublisher.test.ts
@@ -2,8 +2,13 @@ import mockFetch from '../../stubs/Fetch'
 import mockLogger from '../../stubs/Logger'
 import EventPublisher from '../../../src/Services/HomeAssistant/EventPublisher'
 
-function assertSendEvent (event: string, data: any, supervisorToken: string): void {
-    expect(mockFetch).toHaveBeenCalledWith(`http://supervisor/core/api/events/${event}`, {
+const supervisorToken = 'token'
+const haBaseUrl = 'http://ha:8123'
+
+function assertSendEvent (event: string, data: any, baseUrl?: string): void {
+    baseUrl = baseUrl ?? 'http://supervisor/core'
+
+    expect(mockFetch).toHaveBeenCalledWith(`${baseUrl}/api/events/${event}`, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
@@ -18,17 +23,30 @@ describe('HA Event Publisher', () => {
         jest.clearAllMocks()
     })
 
-    it('returns 200', async () => {
+    it('send to supervisord', async () => {
         mockFetch.mockResolvedValue({
             status: 200,
             statusText: 'OK'
         })
 
-        const publisher = new EventPublisher(mockLogger)
-        await publisher.publish('test_event', { test: 'test' }, 'test_token')
+        const publisher = new EventPublisher(mockLogger, supervisorToken)
+        await publisher.publish('test_event', { test: 'test' })
 
         expect(mockLogger.info).toBeCalledWith('Event test_event published to Home Assistant')
-        assertSendEvent('test_event', { test: 'test' }, 'test_token')
+        assertSendEvent('test_event', { test: 'test' })
+    })
+
+    it('send to HA', async () => {
+        mockFetch.mockResolvedValue({
+            status: 200,
+            statusText: 'OK'
+        })
+
+        const publisher = new EventPublisher(mockLogger, supervisorToken, haBaseUrl)
+        await publisher.publish('test_event', { test: 'test' })
+
+        expect(mockLogger.info).toBeCalledWith('Event test_event published to Home Assistant')
+        assertSendEvent('test_event', { test: 'test' }, haBaseUrl)
     })
 
     it('returns 500', async () => {
@@ -37,20 +55,20 @@ describe('HA Event Publisher', () => {
             statusText: 'Internal Server Error'
         })
 
-        const publisher = new EventPublisher(mockLogger)
-        await publisher.publish('test_event', { test: 'test' }, 'test_token')
+        const publisher = new EventPublisher(mockLogger, supervisorToken)
+        await publisher.publish('test_event', { test: 'test' })
 
-        assertSendEvent('test_event', { test: 'test' }, 'test_token')
+        assertSendEvent('test_event', { test: 'test' })
         expect(mockLogger.error).toBeCalledWith('Error publishing event test_event to Home Assistant: Internal Server Error')
     })
 
     it('throws error', async () => {
         mockFetch.mockRejectedValue(new Error('Test Error'))
 
-        const publisher = new EventPublisher(mockLogger)
-        await publisher.publish('test_event', { test: 'test' }, 'test_token')
+        const publisher = new EventPublisher(mockLogger, supervisorToken)
+        await publisher.publish('test_event', { test: 'test' })
 
-        assertSendEvent('test_event', { test: 'test' }, 'test_token')
+        assertSendEvent('test_event', { test: 'test' })
         expect(mockLogger.error).toBeCalledWith('Error sending event to Home Assistant', new Error('Test Error'))
     })
 })


### PR DESCRIPTION
Added support for ha core api by defining the environment variable `HA_BASE_URL` with base url.
Example `http://ha-ip:8123`