### PR TITLE
Add new Home Assistant events

### DIFF
--- a/src/Libs/HomeAssistant.ts
+++ b/src/Libs/HomeAssistant.ts
@@ -25,7 +25,6 @@ export default class HomeAssistant implements IHomeAssistant {
         this.logger.info('Home Assistant integration enabled')
 
         this.eventBus.register('whatsapp.authenticated', this.onAuthenticated.bind(this))
-        this.eventBus.register('whatsapp.auth_failure', this.onAuthFailure.bind(this))
         this.eventBus.register('whatsapp.disconnected', this.onDisconnected.bind(this))
         this.eventBus.register('whatsapp.message', this.onMessage.bind(this))
         this.eventBus.register('whatsapp.message.create', this.onCreatedMessage.bind(this))
@@ -42,11 +41,6 @@ export default class HomeAssistant implements IHomeAssistant {
     private async onAuthenticated (): Promise<void> {
         this.logger.info('onAuthenticated')
         await this.sendToHomeAssistant('authenticated', {})
-    }
-
-    private async onAuthFailure (data: IAuthFailureEvent): Promise<void> {
-        this.logger.info('onAuthFailure')
-        await this.sendToHomeAssistant('auth_failure', data)
     }
 
     private async onDisconnected (): Promise<void> {

--- a/src/Libs/HomeAssistant.ts
+++ b/src/Libs/HomeAssistant.ts
@@ -1,7 +1,7 @@
 import { IEventPublisher } from './../Services/HomeAssistant/EventPublisher'
 import { IEventBus } from './EventBus'
 import { ILogger } from './Logger'
-import { IMessageAckEvent, IMessageEvent, IStateChangeEvent } from './Whatsapp'
+import { IMessageAckEvent, IMessageEvent, IStateChangeEvent, IAuthFailureEvent, IMessageRevokeForEveryoneEvent, IMessageRevokeForMeEvent, IGroupNotificationEvent, ICallEvent } from './Whatsapp'
 
 export interface IHomeAssistant {
     start: () => void
@@ -24,12 +24,34 @@ export default class HomeAssistant implements IHomeAssistant {
 
         this.logger.info('Home Assistant integration enabled')
 
+        this.eventBus.register('whatsapp.authenticated', this.onAuthenticated.bind(this))
+        this.eventBus.register('whatsapp.auth_failure', this.onAuthFailure.bind(this))
+        this.eventBus.register('whatsapp.disconnected', this.onDisconnected.bind(this))
         this.eventBus.register('whatsapp.message', this.onMessage.bind(this))
         this.eventBus.register('whatsapp.message.create', this.onCreatedMessage.bind(this))
         this.eventBus.register('whatsapp.message.ack', this.onMessageAck.bind(this))
+        this.eventBus.register('whatsapp.message.revoke_for_everyone', this.onMessageRevokeForEveryone.bind(this))
+        this.eventBus.register('whatsapp.message.revoke_for_me', this.onMessageRevokeForMe.bind(this))
+        this.eventBus.register('whatsapp.group.join', this.onGroupJoin.bind(this))
+        this.eventBus.register('whatsapp.group.leave', this.onGroupLeave.bind(this))
+        this.eventBus.register('whatsapp.group.update', this.onGroupUpdate.bind(this))
+        this.eventBus.register('whatsapp.call', this.onCall.bind(this))
         this.eventBus.register('whatsapp.state', this.onChangedState.bind(this))
-        this.eventBus.register('whatsapp.authenticated', this.onAuthenticated.bind(this))
-        this.eventBus.register('whatsapp.disconnected', this.onDisconnected.bind(this))
+    }
+
+    private async onAuthenticated (): Promise<void> {
+        this.logger.info('onAuthenticated')
+        await this.sendToHomeAssistant('authenticated', {})
+    }
+
+    private async onAuthFailure (data: IAuthFailureEvent): Promise<void> {
+        this.logger.info('onAuthFailure')
+        await this.sendToHomeAssistant('auth_failure', data)
+    }
+
+    private async onDisconnected (): Promise<void> {
+        this.logger.info('onDisconnected')
+        await this.sendToHomeAssistant('disconnected', {})
     }
 
     private async onMessage (data: IMessageEvent): Promise<void> {
@@ -52,19 +74,44 @@ export default class HomeAssistant implements IHomeAssistant {
         await this.sendToHomeAssistant('message_ack', event)
     }
 
+    private async onMessageRevokeForEveryone (data: IMessageRevokeForEveryoneEvent): Promise<void> {
+        this.logger.info('onMessageRevokeForEveryone', data.message.id)
+        await this.sendToHomeAssistant('message_revoke_for_everyone', {
+            message: data.message.rawData,
+            revokedMessage: data.revokedMessage.rawData
+        })
+    }
+
+    private async onMessageRevokeForMe (data: IMessageRevokeForMeEvent): Promise<void> {
+        this.logger.info('onMessageRevokeForMe', data.message.id)
+        await this.sendToHomeAssistant('message_revoke_for_me', {
+            message: data.message.rawData
+        })
+    }
+
+    private async onGroupJoin (data: IGroupNotificationEvent): Promise<void> {
+        this.logger.info('onGroupJoin', data)
+        await this.sendToHomeAssistant('group_join', data)
+    }
+
+    private async onGroupLeave (data: IGroupNotificationEvent): Promise<void> {
+        this.logger.info('onGroupLeave', data)
+        await this.sendToHomeAssistant('group_leave', data)
+    }
+
+    private async onGroupUpdate (data: IGroupNotificationEvent): Promise<void> {
+        this.logger.info('onGroupUpdate', data)
+        await this.sendToHomeAssistant('group_update', data)
+    }
+
+    private async onCall (data: ICallEvent): Promise<void> {
+        this.logger.info('onCall', data)
+        await this.sendToHomeAssistant('call', data)
+    }
+
     private async onChangedState (data: IStateChangeEvent): Promise<void> {
         this.logger.info('onChangedState', data)
         await this.sendToHomeAssistant('state', data)
-    }
-
-    private async onAuthenticated (): Promise<void> {
-        this.logger.info('onAuthenticated')
-        await this.sendToHomeAssistant('authenticated', {})
-    }
-
-    private async onDisconnected (): Promise<void> {
-        this.logger.info('onDisconnected')
-        await this.sendToHomeAssistant('disconnected', {})
     }
 
     private async sendToHomeAssistant (event: string, data: any): Promise<void> {

--- a/src/Libs/HomeAssistant.ts
+++ b/src/Libs/HomeAssistant.ts
@@ -1,7 +1,7 @@
 import { IEventPublisher } from './../Services/HomeAssistant/EventPublisher'
 import { IEventBus } from './EventBus'
 import { ILogger } from './Logger'
-import { IMessageAckEvent, IMessageEvent, IStateChangeEvent, IAuthFailureEvent, IMessageRevokeForEveryoneEvent, IMessageRevokeForMeEvent, IGroupNotificationEvent, ICallEvent } from './Whatsapp'
+import { IMessageAckEvent, IMessageEvent, IStateChangeEvent, IMessageRevokeForEveryoneEvent, IMessageRevokeForMeEvent, IGroupNotificationEvent, ICallEvent } from './Whatsapp'
 
 export interface IHomeAssistant {
     start: () => void

--- a/src/Libs/HomeAssistant.ts
+++ b/src/Libs/HomeAssistant.ts
@@ -34,7 +34,7 @@ export default class HomeAssistant implements IHomeAssistant {
         this.eventBus.register('whatsapp.group.join', this.onGroupJoin.bind(this))
         this.eventBus.register('whatsapp.group.leave', this.onGroupLeave.bind(this))
         this.eventBus.register('whatsapp.group.update', this.onGroupUpdate.bind(this))
-        this.eventBus.register('whatsapp.call', this.onCall.bind(this))
+        this.eventBus.register('whatsapp.incoming_call', this.onCall.bind(this))
         this.eventBus.register('whatsapp.state', this.onChangedState.bind(this))
     }
 

--- a/src/Libs/WebSocket.ts
+++ b/src/Libs/WebSocket.ts
@@ -2,7 +2,7 @@ import { Server, Socket } from 'socket.io'
 import http from 'http'
 import { ILogger } from './Logger'
 import { IEventBus } from './EventBus'
-import { IQRCodeEvent, IMessageEvent, IMessageAckEvent, IStateChangeEvent } from './Whatsapp'
+import { IQRCodeEvent, IMessageEvent, IMessageAckEvent, IStateChangeEvent, IMessageRevokeForEveryoneEvent, IMessageRevokeForMeEvent, IGroupNotificationEvent, ICallEvent } from './Whatsapp'
 import qrCode from 'qrcode'
 
 export interface IWebSocket {
@@ -21,12 +21,19 @@ export default class WebSocket implements IWebSocket {
         this.logger.info('Starting WebSocket')
         this.io = new Server(this.httpServer)
         this.io.on('connection', this.onConnection.bind(this))
+        this.eventBus.register('whatsapp.authenticated', this.onAuthenticated.bind(this))
+        this.eventBus.register('whatsapp.auth_failure', this.onAuthFailure.bind(this))
+        this.eventBus.register('whatsapp.disconnected', this.onDisconnected.bind(this))
         this.eventBus.register('whatsapp.message', this.onMessage.bind(this))
         this.eventBus.register('whatsapp.message.create', this.onCreatedMessage.bind(this))
         this.eventBus.register('whatsapp.message.ack', this.onMessageAck.bind(this))
+        this.eventBus.register('whatsapp.revoke_for_everyone', this.onMessageRevokeForEveryone.bind(this))
+        this.eventBus.register('whatsapp.revoke_for_me', this.onMessageRevokeForMe.bind(this))
+        this.eventBus.register('whatsapp.group.join', this.onGroupJoin.bind(this))
+        this.eventBus.register('whatsapp.group.leave', this.onGroupLeave.bind(this))
+        this.eventBus.register('whatsapp.group.update', this.onGroupUpdate.bind(this))
+        this.eventBus.register('whatsapp.call', this.onCall.bind(this))
         this.eventBus.register('whatsapp.state', this.onChangedState.bind(this))
-        this.eventBus.register('whatsapp.authenticated', this.onAuthenticated.bind(this))
-        this.eventBus.register('whatsapp.disconnected', this.onDisconnected.bind(this))
     }
 
     public stop (): void {
@@ -70,6 +77,42 @@ export default class WebSocket implements IWebSocket {
         this.logger.info('New message ack')
     }
 
+    private onMessageRevokeForEveryone (data: IMessageRevokeForEveryoneEvent): void {
+        this.io.emit('message.revoke_for_everyone', {
+            message: data.message.rawData,
+            revokedMessage: data.revokedMessage.rawData
+        })
+        this.logger.info('Message revoke for everyone')
+    }
+
+    private onMessageRevokeForMe (data: IMessageRevokeForMeEvent): void {
+        this.io.emit('message.revoke_for_me', {
+            message: data.message.rawData
+        })
+
+        this.logger.info('Message revoke for me')
+    }
+
+    private onGroupJoin (data: IGroupNotificationEvent): void {
+        this.io.emit('group.join', data)
+        this.logger.info('Group join')
+    }
+
+    private onGroupLeave (data: IGroupNotificationEvent): void {
+        this.io.emit('group.leave', data)
+        this.logger.info('Group leave')
+    }
+
+    private onGroupUpdate (data: IGroupNotificationEvent): void {
+        this.io.emit('group.update', data)
+        this.logger.info('Group update')
+    }
+
+    private onCall (data: ICallEvent): void {
+        this.io.emit('call', data)
+        this.logger.info('Call')
+    }
+
     private onChangedState (data: IStateChangeEvent): void {
         this.io.emit('state.change', data)
         this.logger.info('New state change')
@@ -80,8 +123,13 @@ export default class WebSocket implements IWebSocket {
         this.logger.info('Authenticated')
     }
 
-    private onDisconnected (): void {
-        this.io.emit('disconnected')
+    private onAuthFailure (message: string): void {
+        this.io.emit('auth_failure', { message })
+        this.logger.info('Auth failure')
+    }
+
+    private onDisconnected (state: IStateChangeEvent): void {
+        this.io.emit('disconnected', state)
         this.logger.info('Disconnected')
     }
 }

--- a/src/Libs/WebSocket.ts
+++ b/src/Libs/WebSocket.ts
@@ -2,7 +2,7 @@ import { Server, Socket } from 'socket.io'
 import http from 'http'
 import { ILogger } from './Logger'
 import { IEventBus } from './EventBus'
-import { IQRCodeEvent, IMessageEvent, IMessageAckEvent, IStateChangeEvent, IMessageRevokeForEveryoneEvent, IMessageRevokeForMeEvent, IGroupNotificationEvent, ICallEvent } from './Whatsapp'
+import { IQRCodeEvent, IMessageEvent, IMessageAckEvent, IStateChangeEvent, IMessageRevokeForEveryoneEvent, IMessageRevokeForMeEvent, IGroupNotificationEvent, ICallEvent, IAuthFailureEvent } from './Whatsapp'
 import qrCode from 'qrcode'
 
 export interface IWebSocket {
@@ -123,8 +123,8 @@ export default class WebSocket implements IWebSocket {
         this.logger.info('Authenticated')
     }
 
-    private onAuthFailure (message: string): void {
-        this.io.emit('auth_failure', { message })
+    private onAuthFailure (data: IAuthFailureEvent): void {
+        this.io.emit('auth_failure', data)
         this.logger.info('Auth failure')
     }
 

--- a/src/Libs/Whatsapp.ts
+++ b/src/Libs/Whatsapp.ts
@@ -10,6 +10,10 @@ export interface IWhatsapp {
     getClient: () => Client
 }
 
+export interface IAuthFailureEvent {
+    message: string
+}
+
 export interface IQRCodeEvent {
     qr: string
 }
@@ -96,8 +100,12 @@ export default class Whatsapp implements IWhatsapp {
     }
 
     private onAuthFailure (message: string): void {
-        this.logger.error('Client authentication failure', message)
-        this.eventBus.dispatch('whatsapp.auth_failure', message)
+        const event: IAuthFailureEvent = {
+            message
+        }
+
+        this.logger.error('Client authentication failure', event)
+        this.eventBus.dispatch('whatsapp.auth_failure', event)
     }
 
     private async onDisconnected (reason: WAWebJS.WAState): Promise<void> {
@@ -108,7 +116,7 @@ export default class Whatsapp implements IWhatsapp {
             state: reason
         }
 
-        this.logger.info('Client is disconnected reason: ' + reason)
+        this.logger.info('Client is disconnected', reason)
         this.eventBus.dispatch('whatsapp.disconnected', event)
     }
 

--- a/src/Libs/Whatsapp.ts
+++ b/src/Libs/Whatsapp.ts
@@ -32,6 +32,14 @@ export interface IMessageRevokeForMeEvent {
     message: WAWebJS.Message
 }
 
+export interface IGroupNotificationEvent {
+    notification: WAWebJS.GroupNotification
+}
+
+export interface ICallEvent {
+    call: WAWebJS.Call
+}
+
 export interface IStateChangeEvent {
     state: WAWebJS.WAState
 }
@@ -51,12 +59,17 @@ export default class Whatsapp implements IWhatsapp {
         this.client.on('ready', this.onReady.bind(this))
         this.client.on('loading_screen', this.onLoadingScreen.bind(this))
         this.client.on('authenticated', this.onAuthenticated.bind(this))
+        this.client.on('auth_failure', this.onAuthFailure.bind(this))
         this.client.on('disconnected', this.onDisconnected.bind(this))
         this.client.on('message', this.onMessage.bind(this))
         this.client.on('message_create', this.onMessageCreate.bind(this))
         this.client.on('message_ack', this.onMessageAck.bind(this))
         this.client.on('message_revoke_everyone', this.onMessageRevokeForEveryone.bind(this))
         this.client.on('message_revoke_me', this.onMessageRevokeForMe.bind(this))
+        this.client.on('group_join', this.onGroupJoin.bind(this))
+        this.client.on('group_leave', this.onGroupLeave.bind(this))
+        this.client.on('group_update', this.onGroupUpdate.bind(this))
+        this.client.on('call', this.onCall.bind(this))
         this.client.on('change_state', this.onChangeState.bind(this))
 
         return await this.client.initialize().then(() => {
@@ -82,12 +95,21 @@ export default class Whatsapp implements IWhatsapp {
         this.eventBus.dispatch('whatsapp.authenticated')
     }
 
-    private async onDisconnected (): Promise<void> {
+    private onAuthFailure (message: string): void {
+        this.logger.error('Client authentication failure', message)
+        this.eventBus.dispatch('whatsapp.auth_failure', message)
+    }
+
+    private async onDisconnected (reason: WAWebJS.WAState): Promise<void> {
         await this.client.destroy()
         await this.client.initialize()
 
-        this.logger.info('Client is disconnected')
-        this.eventBus.dispatch('whatsapp.disconnected')
+        const event: IStateChangeEvent = {
+            state: reason
+        }
+
+        this.logger.info('Client is disconnected reason: ' + reason)
+        this.eventBus.dispatch('whatsapp.disconnected', event)
     }
 
     private onLoadingScreen (): void {
@@ -163,6 +185,46 @@ export default class Whatsapp implements IWhatsapp {
         }
 
         this.eventBus.dispatch('whatsapp.message.revoke_for_me', event)
+    }
+
+    private onGroupJoin (notification: WAWebJS.GroupNotification): void {
+        this.logger.info('Group join', notification.id)
+
+        const event: IGroupNotificationEvent = {
+            notification
+        }
+
+        this.eventBus.dispatch('whatsapp.group.join', event)
+    }
+
+    private onGroupLeave (notification: WAWebJS.GroupNotification): void {
+        this.logger.info('Group leave', notification.id)
+
+        const event: IGroupNotificationEvent = {
+            notification
+        }
+
+        this.eventBus.dispatch('whatsapp.group.leave', event)
+    }
+
+    private onGroupUpdate (notification: WAWebJS.GroupNotification): void {
+        this.logger.info('Group update', notification.id)
+
+        const event: IGroupNotificationEvent = {
+            notification
+        }
+
+        this.eventBus.dispatch('whatsapp.group.update', event)
+    }
+
+    private onCall (call: WAWebJS.Call): void {
+        this.logger.info('Call', call.id)
+
+        const event: ICallEvent = {
+            call
+        }
+
+        this.eventBus.dispatch('whatsapp.call', event)
     }
 
     private onChangeState (state: WAWebJS.WAState): void {

--- a/src/Libs/Whatsapp.ts
+++ b/src/Libs/Whatsapp.ts
@@ -73,7 +73,7 @@ export default class Whatsapp implements IWhatsapp {
         this.client.on('group_join', this.onGroupJoin.bind(this))
         this.client.on('group_leave', this.onGroupLeave.bind(this))
         this.client.on('group_update', this.onGroupUpdate.bind(this))
-        this.client.on('call', this.onCall.bind(this))
+        this.client.on('incoming_call', this.onCall.bind(this))
         this.client.on('change_state', this.onChangeState.bind(this))
 
         return await this.client.initialize().then(() => {

--- a/tests/Libs/HomeAssistant.test.ts
+++ b/tests/Libs/HomeAssistant.test.ts
@@ -2,6 +2,12 @@ import mockLogger from '../stubs/Logger'
 import mockEventBus from '../stubs/EventBus'
 import mockEventPublisher from '../stubs/HaEventPublisher'
 import HomeAssistant from './../../src/Libs/HomeAssistant'
+import { findCallback } from '../utils/Utils'
+
+const mockStartHomeAssistant = (): void => {
+    const ha = new HomeAssistant(mockLogger, mockEventBus, mockEventPublisher)
+    ha.start()
+}
 
 describe('Home assistant', () => {
     afterEach(() => {
@@ -9,8 +15,7 @@ describe('Home assistant', () => {
     })
 
     it('not start ha service', async () => {
-        const ha = new HomeAssistant(mockLogger, mockEventBus, mockEventPublisher)
-        ha.start()
+        mockStartHomeAssistant()
 
         expect(mockLogger.warn).toHaveBeenCalledWith('Home Assistant integration disabled')
     })
@@ -18,25 +23,70 @@ describe('Home assistant', () => {
     it('start ha service', async () => {
         process.env.SUPERVISOR_TOKEN = 'token'
 
-        const ha = new HomeAssistant(mockLogger, mockEventBus, mockEventPublisher)
-        ha.start()
+        mockStartHomeAssistant()
 
         expect(mockLogger.info).toHaveBeenCalledWith('Home Assistant integration enabled')
+        expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.authenticated', expect.any(Function))
+        expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.auth_failure', expect.any(Function))
+        expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.disconnected', expect.any(Function))
         expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.message', expect.any(Function))
         expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.message.create', expect.any(Function))
         expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.message.ack', expect.any(Function))
+        expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.message.revoke_for_everyone', expect.any(Function))
+        expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.message.revoke_for_me', expect.any(Function))
+        expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.group.join', expect.any(Function))
+        expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.group.leave', expect.any(Function))
+        expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.group.update', expect.any(Function))
+        expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.call', expect.any(Function))
         expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.state', expect.any(Function))
-        expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.authenticated', expect.any(Function))
-        expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.disconnected', expect.any(Function))
+    })
+
+    it('onAuthenticated', async () => {
+        process.env.SUPERVISOR_TOKEN = 'token'
+
+        mockStartHomeAssistant()
+
+        const onAuthenticated = findCallback(mockEventBus.register.mock, 'whatsapp.authenticated')
+        await onAuthenticated('message')
+
+        expect(mockLogger.info).toHaveBeenCalledWith('onAuthenticated')
+        expect(mockEventPublisher.publish).toHaveBeenCalledWith('whatsapp_authenticated', {})
+    })
+
+    it('onAuthFailure', async () => {
+        process.env.SUPERVISOR_TOKEN = 'token'
+
+        mockStartHomeAssistant()
+
+        const event = {
+            message: 'message'
+        }
+
+        const onAuthFailure = findCallback(mockEventBus.register.mock, 'whatsapp.auth_failure')
+        await onAuthFailure(event)
+
+        expect(mockLogger.info).toHaveBeenCalledWith('onAuthFailure')
+        expect(mockEventPublisher.publish).toHaveBeenCalledWith('whatsapp_auth_failure', event)
+    })
+
+    it('onDisconnected', async () => {
+        process.env.SUPERVISOR_TOKEN = 'token'
+
+        mockStartHomeAssistant()
+
+        const onDisconnected = findCallback(mockEventBus.register.mock, 'whatsapp.disconnected')
+        await onDisconnected()
+
+        expect(mockLogger.info).toHaveBeenCalledWith('onDisconnected')
+        expect(mockEventPublisher.publish).toHaveBeenCalledWith('whatsapp_disconnected', {})
     })
 
     it('onMessage', async () => {
         process.env.SUPERVISOR_TOKEN = 'token'
 
-        const ha = new HomeAssistant(mockLogger, mockEventBus, mockEventPublisher)
-        ha.start()
+        mockStartHomeAssistant()
 
-        const onMessage = mockEventBus.register.mock.calls[0][1]
+        const onMessage = findCallback(mockEventBus.register.mock, 'whatsapp.message')
         await onMessage({ message: { id: 'id', rawData: { id: 'id' } } })
 
         expect(mockLogger.info).toHaveBeenCalledWith('onMessage', 'id')
@@ -46,10 +96,9 @@ describe('Home assistant', () => {
     it('onCreatedMessage', async () => {
         process.env.SUPERVISOR_TOKEN = 'token'
 
-        const ha = new HomeAssistant(mockLogger, mockEventBus, mockEventPublisher)
-        ha.start()
+        mockStartHomeAssistant()
 
-        const onCreatedMessage = mockEventBus.register.mock.calls[1][1]
+        const onCreatedMessage = findCallback(mockEventBus.register.mock, 'whatsapp.message.create')
         await onCreatedMessage({ message: { id: 'id', rawData: { id: 'id' } } })
 
         expect(mockLogger.info).toHaveBeenCalledWith('onCreatedMessage', 'id')
@@ -59,10 +108,9 @@ describe('Home assistant', () => {
     it('onMessageAck', async () => {
         process.env.SUPERVISOR_TOKEN = 'token'
 
-        const ha = new HomeAssistant(mockLogger, mockEventBus, mockEventPublisher)
-        ha.start()
+        mockStartHomeAssistant()
 
-        const onMessageAck = mockEventBus.register.mock.calls[2][1]
+        const onMessageAck = findCallback(mockEventBus.register.mock, 'whatsapp.message.ack')
         await onMessageAck({ message: { id: 'id', rawData: { id: 'id' } }, ack: 1 })
 
         const event = { message: { id: 'id' }, ack: 1 }
@@ -71,41 +119,116 @@ describe('Home assistant', () => {
         expect(mockEventPublisher.publish).toHaveBeenCalledWith('whatsapp_message_ack', event)
     })
 
+    it('onMessageRevokeForEveryone', async () => {
+        process.env.SUPERVISOR_TOKEN = 'token'
+
+        mockStartHomeAssistant()
+
+        const message = { id: 'id', rawData: { id: 'id' } }
+
+        const onMessageRevokeForEveryone = findCallback(mockEventBus.register.mock, 'whatsapp.message.revoke_for_everyone')
+        await onMessageRevokeForEveryone({ message, revokedMessage: message })
+
+        const event = { message: message.rawData, revokedMessage: message.rawData }
+
+        expect(mockLogger.info).toHaveBeenCalledWith('onMessageRevokeForEveryone', 'id')
+        expect(mockEventPublisher.publish).toHaveBeenCalledWith('whatsapp_message_revoke_for_everyone', event)
+    })
+
+    it('onMessageRevokeForMe', async () => {
+        process.env.SUPERVISOR_TOKEN = 'token'
+
+        mockStartHomeAssistant()
+
+        const message = { id: 'id', rawData: { id: 'id' } }
+
+        const onMessageRevokeForMe = findCallback(mockEventBus.register.mock, 'whatsapp.message.revoke_for_me')
+        await onMessageRevokeForMe({ message })
+
+        const event = { message: message.rawData }
+
+        expect(mockLogger.info).toHaveBeenCalledWith('onMessageRevokeForMe', 'id')
+        expect(mockEventPublisher.publish).toHaveBeenCalledWith('whatsapp_message_revoke_for_me', event)
+    })
+
+    it('onGroupJoin', async () => {
+        process.env.SUPERVISOR_TOKEN = 'token'
+
+        mockStartHomeAssistant()
+
+        const onGroupJoin = findCallback(mockEventBus.register.mock, 'whatsapp.group.join')
+
+        const event = {
+            group: {}
+        }
+
+        await onGroupJoin(event)
+
+        expect(mockLogger.info).toHaveBeenCalledWith('onGroupJoin', event)
+        expect(mockEventPublisher.publish).toHaveBeenCalledWith('whatsapp_group_join', event)
+    })
+
+    it('onGroupLeave', async () => {
+        process.env.SUPERVISOR_TOKEN = 'token'
+
+        mockStartHomeAssistant()
+
+        const onGroupLeave = findCallback(mockEventBus.register.mock, 'whatsapp.group.leave')
+
+        const event = {
+            group: {}
+        }
+
+        await onGroupLeave(event)
+
+        expect(mockLogger.info).toHaveBeenCalledWith('onGroupLeave', event)
+        expect(mockEventPublisher.publish).toHaveBeenCalledWith('whatsapp_group_leave', event)
+    })
+
+    it('onGroupUpdate', async () => {
+        process.env.SUPERVISOR_TOKEN = 'token'
+
+        mockStartHomeAssistant()
+
+        const onGroupUpdate = findCallback(mockEventBus.register.mock, 'whatsapp.group.update')
+
+        const event = {
+            group: {}
+        }
+
+        await onGroupUpdate(event)
+
+        expect(mockLogger.info).toHaveBeenCalledWith('onGroupUpdate', event)
+        expect(mockEventPublisher.publish).toHaveBeenCalledWith('whatsapp_group_update', event)
+    })
+
+    it('onCall', async () => {
+        process.env.SUPERVISOR_TOKEN = 'token'
+
+        mockStartHomeAssistant()
+
+        const onCall = findCallback(mockEventBus.register.mock, 'whatsapp.call')
+
+        const event = {
+            call: {}
+        }
+
+        await onCall(event)
+
+        expect(mockLogger.info).toHaveBeenCalledWith('onCall', event)
+        expect(mockEventPublisher.publish).toHaveBeenCalledWith('whatsapp_call', event)
+    })
+
     it('onState', async () => {
         process.env.SUPERVISOR_TOKEN = 'token'
 
-        const ha = new HomeAssistant(mockLogger, mockEventBus, mockEventPublisher)
-        ha.start()
+        mockStartHomeAssistant()
 
         const event = { state: 'state' }
-        const onState = mockEventBus.register.mock.calls[3][1]
+        const onState = findCallback(mockEventBus.register.mock, 'whatsapp.state')
         await onState(event)
 
         expect(mockLogger.info).toHaveBeenCalledWith('onChangedState', event)
         expect(mockEventPublisher.publish).toHaveBeenCalledWith('whatsapp_state', event)
-    })
-
-    it('onAuthenticated', async () => {
-        process.env.SUPERVISOR_TOKEN = 'token'
-
-        const ha = new HomeAssistant(mockLogger, mockEventBus, mockEventPublisher)
-        ha.start()
-        const onAuthenticated = mockEventBus.register.mock.calls[4][1]
-        await onAuthenticated()
-
-        expect(mockLogger.info).toHaveBeenCalledWith('onAuthenticated')
-        expect(mockEventPublisher.publish).toHaveBeenCalledWith('whatsapp_authenticated', {})
-    })
-
-    it('onDisconnected', async () => {
-        process.env.SUPERVISOR_TOKEN = 'token'
-
-        const ha = new HomeAssistant(mockLogger, mockEventBus, mockEventPublisher)
-        ha.start()
-        const onDisconnected = mockEventBus.register.mock.calls[5][1]
-        await onDisconnected()
-
-        expect(mockLogger.info).toHaveBeenCalledWith('onDisconnected')
-        expect(mockEventPublisher.publish).toHaveBeenCalledWith('whatsapp_disconnected', {})
     })
 })

--- a/tests/Libs/HomeAssistant.test.ts
+++ b/tests/Libs/HomeAssistant.test.ts
@@ -36,7 +36,6 @@ describe('Home assistant', () => {
         expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.group.join', expect.any(Function))
         expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.group.leave', expect.any(Function))
         expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.group.update', expect.any(Function))
-        expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.call', expect.any(Function))
         expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.state', expect.any(Function))
     })
 
@@ -183,23 +182,6 @@ describe('Home assistant', () => {
 
         expect(mockLogger.info).toHaveBeenCalledWith('onGroupUpdate', event)
         expect(mockEventPublisher.publish).toHaveBeenCalledWith('whatsapp_group_update', event)
-    })
-
-    it('onCall', async () => {
-        process.env.SUPERVISOR_TOKEN = 'token'
-
-        mockStartHomeAssistant()
-
-        const onCall = findCallback(mockEventBus.register.mock, 'whatsapp.call')
-
-        const event = {
-            call: {}
-        }
-
-        await onCall(event)
-
-        expect(mockLogger.info).toHaveBeenCalledWith('onCall', event)
-        expect(mockEventPublisher.publish).toHaveBeenCalledWith('whatsapp_call', event)
     })
 
     it('onState', async () => {

--- a/tests/Libs/HomeAssistant.test.ts
+++ b/tests/Libs/HomeAssistant.test.ts
@@ -27,7 +27,6 @@ describe('Home assistant', () => {
 
         expect(mockLogger.info).toHaveBeenCalledWith('Home Assistant integration enabled')
         expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.authenticated', expect.any(Function))
-        expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.auth_failure', expect.any(Function))
         expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.disconnected', expect.any(Function))
         expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.message', expect.any(Function))
         expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.message.create', expect.any(Function))
@@ -51,22 +50,6 @@ describe('Home assistant', () => {
 
         expect(mockLogger.info).toHaveBeenCalledWith('onAuthenticated')
         expect(mockEventPublisher.publish).toHaveBeenCalledWith('whatsapp_authenticated', {})
-    })
-
-    it('onAuthFailure', async () => {
-        process.env.SUPERVISOR_TOKEN = 'token'
-
-        mockStartHomeAssistant()
-
-        const event = {
-            message: 'message'
-        }
-
-        const onAuthFailure = findCallback(mockEventBus.register.mock, 'whatsapp.auth_failure')
-        await onAuthFailure(event)
-
-        expect(mockLogger.info).toHaveBeenCalledWith('onAuthFailure')
-        expect(mockEventPublisher.publish).toHaveBeenCalledWith('whatsapp_auth_failure', event)
     })
 
     it('onDisconnected', async () => {

--- a/tests/Libs/WebSocket.test.ts
+++ b/tests/Libs/WebSocket.test.ts
@@ -101,21 +101,25 @@ describe('WebSocket tests', () => {
         mockStartWebSocket()
 
         const onAuthFailure = findCallback(mockEventBus.register.mock, 'whatsapp.auth_failure')
-        onAuthFailure('message')
+        onAuthFailure({
+            message: 'message'
+        })
 
         expect(mockEmit).toHaveBeenCalledWith('auth_failure', { message: 'message' })
         expect(mockLogger.info).toHaveBeenCalledWith('Auth failure')
     })
 
-    // it('onDisconnected', async () => {
-    //     mockStartWebSocket()
+    it('onDisconnected', async () => {
+        mockStartWebSocket()
 
-    //     const onDisconnected = findCallback(mockEventBus.register.mock, 'whatsapp.disconnected')
-    //     onDisconnected('reason')
+        const onDisconnected = findCallback(mockEventBus.register.mock, 'whatsapp.disconnected')
+        onDisconnected({
+            state: 'reason'
+        })
 
-    //     expect(mockEmit).toHaveBeenCalledWith('disconnected', { reason: 'reason' })
-    //     expect(mockLogger.info).toHaveBeenCalledWith('Disconnected')
-    // })
+        expect(mockEmit).toHaveBeenCalledWith('disconnected', { state: 'reason' })
+        expect(mockLogger.info).toHaveBeenCalledWith('Disconnected')
+    })
 
     it('onMessage', async () => {
         mockStartWebSocket()
@@ -207,5 +211,14 @@ describe('WebSocket tests', () => {
         const onCall = findCallback(mockEventBus.register.mock, 'whatsapp.call')
         onCall(mockData)
         expect(mockEmit).toHaveBeenCalledWith('call', mockData)
+    })
+
+    it('onStateChange', async () => {
+        mockStartWebSocket()
+
+        const mockData = { state: 'state' }
+        const onStateChange = findCallback(mockEventBus.register.mock, 'whatsapp.state')
+        onStateChange(mockData)
+        expect(mockEmit).toHaveBeenCalledWith('state.change', mockData)
     })
 })

--- a/tests/Libs/WebSocket.test.ts
+++ b/tests/Libs/WebSocket.test.ts
@@ -22,7 +22,7 @@ jest.mock('socket.io', () => {
 
 jest.mock('http')
 
-const mockStartWebSocket = () => {
+const mockStartWebSocket = (): void => {
     const http = httpServer.createServer()
     const websocket = new WebSocket(http, new Logger(), mockEventBus)
     websocket.start()

--- a/tests/Libs/WebSocket.test.ts
+++ b/tests/Libs/WebSocket.test.ts
@@ -4,6 +4,7 @@ import WebSocket from '../../src/Libs/WebSocket'
 import Logger from '../../src/Libs/Logger'
 import { IQRCodeEvent } from '../../src/Libs/Whatsapp'
 import httpServer from 'http'
+import { findCallback } from '../utils/Utils'
 
 const mockOn = jest.fn()
 const mockEmit = jest.fn()
@@ -21,24 +22,40 @@ jest.mock('socket.io', () => {
 
 jest.mock('http')
 
-beforeEach(() => {
-    jest.clearAllMocks()
-})
+const mockStartWebSocket = () => {
+    const http = httpServer.createServer()
+    const websocket = new WebSocket(http, new Logger(), mockEventBus)
+    websocket.start()
+}
 
 describe('WebSocket tests', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
     it('start socket', async () => {
-        const http = httpServer.createServer()
-        const websocket = new WebSocket(http, new Logger(), mockEventBus)
-        websocket.start()
+        mockStartWebSocket()
 
         expect(mockLogger.info).toHaveBeenCalledWith('Starting WebSocket')
         expect(mockOn).toHaveBeenCalledWith('connection', expect.any(Function))
+
+        expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.authenticated', expect.any(Function))
+        expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.auth_failure', expect.any(Function))
+        expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.disconnected', expect.any(Function))
+        expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.message', expect.any(Function))
+        expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.message.create', expect.any(Function))
+        expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.message.ack', expect.any(Function))
+        expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.revoke_for_everyone', expect.any(Function))
+        expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.revoke_for_me', expect.any(Function))
+        expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.group.join', expect.any(Function))
+        expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.group.leave', expect.any(Function))
+        expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.group.update', expect.any(Function))
+        expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.call', expect.any(Function))
+        expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.state', expect.any(Function))
     })
 
     it('onConnection', async () => {
-        const http = httpServer.createServer()
-        const websocket = new WebSocket(http, new Logger(), mockEventBus)
-        websocket.start()
+        mockStartWebSocket()
 
         const mockSocket = {
             id: '123',
@@ -56,7 +73,7 @@ describe('WebSocket tests', () => {
         expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.qr', expect.any(Function))
 
         const mockQr = 'mockQr'
-        const onQr = mockEventBus.register.mock.calls.find((call) => call[0] === 'whatsapp.qr')[1]
+        const onQr = findCallback(mockEventBus.register.mock, 'whatsapp.qr')
         const event: IQRCodeEvent = {
             qr: mockQr
         }
@@ -64,42 +81,131 @@ describe('WebSocket tests', () => {
         onQr(event)
         // expect(mockSocket.emit).toHaveBeenCalledWith('qr_code', { data: mockQr })
 
-        const onDisconnect = mockSocket.on.mock.calls[0][1]
+        const onDisconnect = findCallback(mockSocket.on.mock, 'disconnect')
         onDisconnect('reason')
         expect(mockLogger.info).toHaveBeenCalledWith('Disconnect from 123, reason: reason')
         expect(mockEventBus.dispatch).toHaveBeenCalledWith('socket.disconnect', mockSocket)
     })
 
+    it('onAuthenticated', async () => {
+        mockStartWebSocket()
+
+        const onAuthenticated = findCallback(mockEventBus.register.mock, 'whatsapp.authenticated')
+        onAuthenticated()
+
+        expect(mockEmit).toHaveBeenCalledWith('authenticated')
+        expect(mockLogger.info).toHaveBeenCalledWith('Authenticated')
+    })
+
+    it('onAuthFailure', async () => {
+        mockStartWebSocket()
+
+        const onAuthFailure = findCallback(mockEventBus.register.mock, 'whatsapp.auth_failure')
+        onAuthFailure('message')
+
+        expect(mockEmit).toHaveBeenCalledWith('auth_failure', { message: 'message' })
+        expect(mockLogger.info).toHaveBeenCalledWith('Auth failure')
+    })
+
+    // it('onDisconnected', async () => {
+    //     mockStartWebSocket()
+
+    //     const onDisconnected = findCallback(mockEventBus.register.mock, 'whatsapp.disconnected')
+    //     onDisconnected('reason')
+
+    //     expect(mockEmit).toHaveBeenCalledWith('disconnected', { reason: 'reason' })
+    //     expect(mockLogger.info).toHaveBeenCalledWith('Disconnected')
+    // })
+
     it('onMessage', async () => {
-        const http = httpServer.createServer()
-        const websocket = new WebSocket(http, new Logger(), mockEventBus)
-        websocket.start()
+        mockStartWebSocket()
 
         const mockData = { message: { id: 'id', rawData: { id: 'id' } } }
-        const onMessage = mockEventBus.register.mock.calls.find((call) => call[0] === 'whatsapp.message')[1]
+        const onMessage = findCallback(mockEventBus.register.mock, 'whatsapp.message')
         onMessage(mockData)
         expect(mockEmit).toHaveBeenCalledWith('message', mockData.message.rawData)
     })
 
     it('onCreatedMessage', async () => {
-        const http = httpServer.createServer()
-        const websocket = new WebSocket(http, new Logger(), mockEventBus)
-        websocket.start()
+        mockStartWebSocket()
 
         const mockData = { message: { id: 'id', rawData: { id: 'id' } } }
-        const onCreatedMessage = mockEventBus.register.mock.calls.find((call) => call[0] === 'whatsapp.message.create')[1]
+        const onCreatedMessage = findCallback(mockEventBus.register.mock, 'whatsapp.message.create')
         onCreatedMessage(mockData)
         expect(mockEmit).toHaveBeenCalledWith('message.create', mockData.message.rawData)
     })
 
     it('onMessageAck', async () => {
-        const http = httpServer.createServer()
-        const websocket = new WebSocket(http, new Logger(), mockEventBus)
-        websocket.start()
+        mockStartWebSocket()
 
         const mockMessage = { message: { id: 'id', rawData: { id: 'id' } }, ack: 1 }
-        const onMessageAck = mockEventBus.register.mock.calls.find((call) => call[0] === 'whatsapp.message.ack')[1]
+        const onMessageAck = findCallback(mockEventBus.register.mock, 'whatsapp.message.ack')
         onMessageAck(mockMessage)
         expect(mockEmit).toHaveBeenCalledWith('message.ack', { message: mockMessage.message.rawData, ack: mockMessage.ack })
+    })
+
+    it('onRevokeForEveryone', async () => {
+        mockStartWebSocket()
+
+        const message = { id: 'id', rawData: { id: 'id' } }
+        const mockData = { message, revokedMessage: message }
+        const onRevokeForEveryone = findCallback(mockEventBus.register.mock, 'whatsapp.revoke_for_everyone')
+        onRevokeForEveryone(mockData)
+        expect(mockEmit).toHaveBeenCalledWith('message.revoke_for_everyone', {
+            message: mockData.message.rawData,
+            revokedMessage: mockData.revokedMessage.rawData
+        })
+
+        expect(mockLogger.info).toHaveBeenCalledWith('Message revoke for everyone')
+    })
+
+    it('onRevokeForMe', async () => {
+        mockStartWebSocket()
+
+        const message = { id: 'id', rawData: { id: 'id' } }
+        const mockData = { message }
+        const onRevokeForMe = findCallback(mockEventBus.register.mock, 'whatsapp.revoke_for_me')
+        onRevokeForMe(mockData)
+        expect(mockEmit).toHaveBeenCalledWith('message.revoke_for_me', {
+            message: mockData.message.rawData
+        })
+
+        expect(mockLogger.info).toHaveBeenCalledWith('Message revoke for me')
+    })
+
+    it('onGroupJoin', async () => {
+        mockStartWebSocket()
+
+        const mockData = { participant: 'participant', group: 'group' }
+        const onGroupJoin = findCallback(mockEventBus.register.mock, 'whatsapp.group.join')
+        onGroupJoin(mockData)
+        expect(mockEmit).toHaveBeenCalledWith('group.join', mockData)
+    })
+
+    it('onGroupLeave', async () => {
+        mockStartWebSocket()
+
+        const mockData = { participant: 'participant', group: 'group' }
+        const onGroupLeave = findCallback(mockEventBus.register.mock, 'whatsapp.group.leave')
+        onGroupLeave(mockData)
+        expect(mockEmit).toHaveBeenCalledWith('group.leave', mockData)
+    })
+
+    it('onGroupUpdate', async () => {
+        mockStartWebSocket()
+
+        const mockData = { group: 'group' }
+        const onGroupUpdate = findCallback(mockEventBus.register.mock, 'whatsapp.group.update')
+        onGroupUpdate(mockData)
+        expect(mockEmit).toHaveBeenCalledWith('group.update', mockData)
+    })
+
+    it('onCall', async () => {
+        mockStartWebSocket()
+
+        const mockData = { call: 'call' }
+        const onCall = findCallback(mockEventBus.register.mock, 'whatsapp.call')
+        onCall(mockData)
+        expect(mockEmit).toHaveBeenCalledWith('call', mockData)
     })
 })

--- a/tests/Libs/Whatsapp.test.ts
+++ b/tests/Libs/Whatsapp.test.ts
@@ -159,8 +159,8 @@ describe('Whatsapp tests', () => {
         const onAuthFailure = findCallback(mockOn.mock, 'auth_failure')
         onAuthFailure('error')
 
-        expect(mockLogger.error).toHaveBeenCalledWith('Client authentication failure', 'error')
-        expect(mockEventBus.dispatch).toHaveBeenCalledWith('whatsapp.auth_failure', 'error')
+        expect(mockLogger.error).toHaveBeenCalledWith('Client authentication failure', { message: 'error' })
+        expect(mockEventBus.dispatch).toHaveBeenCalledWith('whatsapp.auth_failure', { message: 'error' })
     })
 
     it('onDisconnected', async () => {
@@ -168,10 +168,10 @@ describe('Whatsapp tests', () => {
         await whatsapp.start()
 
         const onDisconnected = findCallback(mockOn.mock, 'disconnected')
-        await onDisconnected()
+        await onDisconnected('reason')
 
-        expect(mockLogger.info).toHaveBeenCalledWith('Client is disconnected')
-        expect(mockEventBus.dispatch).toHaveBeenCalledWith('whatsapp.disconnected')
+        expect(mockLogger.info).toHaveBeenCalledWith('Client is disconnected', 'reason')
+        expect(mockEventBus.dispatch).toHaveBeenCalledWith('whatsapp.disconnected', { state: 'reason' })
     })
 
     it('onMessage', async () => {

--- a/tests/Libs/Whatsapp.test.ts
+++ b/tests/Libs/Whatsapp.test.ts
@@ -106,7 +106,7 @@ describe('Whatsapp tests', () => {
         expect(mockOn).toHaveBeenCalledWith('group_join', expect.any(Function))
         expect(mockOn).toHaveBeenCalledWith('group_leave', expect.any(Function))
         expect(mockOn).toHaveBeenCalledWith('group_update', expect.any(Function))
-        expect(mockOn).toHaveBeenCalledWith('call', expect.any(Function))
+        expect(mockOn).toHaveBeenCalledWith('incoming_call', expect.any(Function))
         expect(mockOn).toHaveBeenCalledWith('change_state', expect.any(Function))
     })
 
@@ -325,7 +325,7 @@ describe('Whatsapp tests', () => {
         const whatsapp = new Whatsapp(new Client({}), mockLogger, mockEventBus)
         await whatsapp.start()
 
-        const onCall = findCallback(mockOn.mock, 'call')
+        const onCall = findCallback(mockOn.mock, 'incoming_call')
         onCall(mockCall)
 
         expect(mockLogger.info).toHaveBeenCalledWith('Call', mockCall.id)

--- a/tests/utils/Utils.ts
+++ b/tests/utils/Utils.ts
@@ -1,4 +1,4 @@
 
-export function findCallback (mock: any, name: string): () => void {
+export function findCallback (mock: any, name: string): (...args: any[]) => void {
     return mock.calls.find((call: any) => call[0] === name)[1]
 }

--- a/tests/utils/Utils.ts
+++ b/tests/utils/Utils.ts
@@ -1,4 +1,4 @@
 
-export function findCallback (mock: any, name: string): Function {
+export function findCallback (mock: any, name: string): () => void {
     return mock.calls.find((call: any) => call[0] === name)[1]
 }

--- a/tests/utils/Utils.ts
+++ b/tests/utils/Utils.ts
@@ -1,0 +1,4 @@
+
+export function findCallback (mock: any, name: string): Function {
+    return mock.calls.find((call: any) => call[0] === name)[1]
+}


### PR DESCRIPTION
### Events
<!-- Table -->
| Event | Description | Data |
| --- | --- | --- |
| `whatsapp_message_revoke_for_everyone` | Triggered when a message is revoked for everyone. | { message: [Message Schema](#message-schema), revokedMessage:  [Message Schema](#message-schema)} |
| `whatsapp_message_revoke_for_me` | Triggered when a message is revoked for you. | { message: [Message Schema](#message-schema)} |
| `whatsapp_message_group_join` | Triggered when a user joins a group. | { [GroupNotification Schema](#groupnotification-schema) } |
| `whatsapp_message_group_leave` | Triggered when a user leaves a group. | { [GroupNotification Schema](#groupnotification-schema) } |
| `whatsapp_message_group_update` | Triggered when a group is updated, such as subject, description or picture. | { [GroupNotification Schema](#groupnotification-schema) } |
| `whatsapp_message_call` | Triggered when a call is received. | { [Call Schema](#call-schema) } |

<br>

### GroupNotification Schema
<!-- Table -->
| Field | Type | Description |
| --- | --- | --- |
| `id` | `object` | The id of the group. |
| `author` | `string` | The ContactId of the author. |
| `body` | `string` | The body of the message. |
| `chatId` | `string` | The id of the chat. |
| `recipientIds` | `string[]` | The ContactIds of the recipients. |
| `timestamp` | `number` | The timestamp of the message. |
| `type` | `enum('add', 'invite',, 'remove', 'leave', 'subject', 'description', 'picture', 'announce', 'restrict')` | The type of the group notification. |

<br>

### Call Schema
<!-- Table -->
| Field | Type | Description |
| --- | --- | --- |
| `id` | `string` | The id of the call. |
| `from` | `string` | The ContactId of the caller. |
| `timestamp` | `number` | The timestamp of the call. |
| `isVideo` | `boolean` | Whether the call is a video call. |
| `isGroup` | `boolean` | Whether the call is a group call. |
| `canHandleLocally` | `boolean` | Whether the call can be handled in waweb |
| `webClientShouldHandle` | `boolean` | Whether the call should be handled in waweb |
| `participants` | `object` | The participants of the call. |

