### PR TITLE
Add message sender options in chat message controller

### DIFF
--- a/src/Services/Message/MediaUrlMessageCreator.ts
+++ b/src/Services/Message/MediaUrlMessageCreator.ts
@@ -1,16 +1,16 @@
 import { IWhatsapp } from '../../Libs/Whatsapp'
-import { Message, MessageMedia } from 'whatsapp-web.js'
+import { Message, MessageMedia, MessageSendOptions } from 'whatsapp-web.js'
 
 export interface IMediaUrlMessageCreator {
-    create: (to: string, url: string) => Promise < Message >
+    create: (to: string, url: string, options?: MessageSendOptions) => Promise < Message >
 }
 
 export default class MediaUrlMessageCreator implements IMediaUrlMessageCreator {
     public constructor (private readonly whatsapp: IWhatsapp) {}
 
-    public async create (to: string, url: string): Promise < Message > {
+    public async create (to: string, url: string, options?: MessageSendOptions): Promise < Message > {
         const message = await MessageMedia.fromUrl(url, { unsafeMime: true })
-        const messageInstance = await this.whatsapp.getClient().sendMessage(to, message)
+        const messageInstance = await this.whatsapp.getClient().sendMessage(to, message, options)
         return messageInstance
     }
 }

--- a/src/Services/Message/TextMessageCreator.ts
+++ b/src/Services/Message/TextMessageCreator.ts
@@ -1,14 +1,14 @@
-import { Message } from 'whatsapp-web.js'
+import { Message, MessageSendOptions } from 'whatsapp-web.js'
 import { IWhatsapp } from '../../Libs/Whatsapp'
 
 export interface ITextMessageCreator {
-    create: (to: string, msg: string) => Promise < Message >
+    create: (to: string, msg: string, options?: MessageSendOptions) => Promise < Message >
 }
 export default class TextMessageCreator implements ITextMessageCreator {
     public constructor (private readonly whatsapp: IWhatsapp) {}
 
-    public async create (to: string, msg: string): Promise < Message > {
-        const messageInstance = await this.whatsapp.getClient().sendMessage(to, msg)
+    public async create (to: string, msg: string, options?: MessageSendOptions): Promise < Message > {
+        const messageInstance = await this.whatsapp.getClient().sendMessage(to, msg, options)
 
         return messageInstance
     }

--- a/src/http/controllers/ChatMessageController.ts
+++ b/src/http/controllers/ChatMessageController.ts
@@ -28,10 +28,25 @@ export const store = (request: Request, response: Response, next: Next) =>
                 chat = chat + '@c.us'
             }
 
+            const options = {
+                linkPreview: request.body.options?.linkPreview,
+                sendAudioAsVoice: request.body.options?.sendAudioAsVoice,
+                sendVideoAsGif: request.body.options?.sendVideoAsGif,
+                sendMediaAsSticker: request.body.options?.sendMediaAsSticker,
+                sendMediaAsDocument: request.body.options?.sendMediaAsDocument,
+                caption: request.body.options?.caption,
+                quotedMessageId: request.body.options?.quotedMessageId,
+                mentions: request.body.options?.mentions,
+                sendSeen: request.body.options?.sendSeen,
+                stickerName: request.body.options?.stickerName,
+                stickerAuthor: request.body.options?.stickerAuthor,
+                stickerCategories: request.body.options?.stickerCategories
+            }
+
             if (url !== undefined) {
-                message = await mediaUrlMessageCreator.create(chat, url)
+                message = await mediaUrlMessageCreator.create(chat, url, options)
             } else {
-                message = await textMessageCreator.create(chat, msg)
+                message = await textMessageCreator.create(chat, msg, options)
             }
 
             return response.json(message.rawData)

--- a/src/http/validators/MessageValidator.ts
+++ b/src/http/validators/MessageValidator.ts
@@ -18,5 +18,18 @@ export default async function (request: Request, response: Response): Promise<vo
         .isURL()
         .run(request)
 
+    await body('options.linkPreview').isBoolean().optional().run(request)
+    await body('options.sendAudioAsVoice').isBoolean().optional().run(request)
+    await body('options.sendVideoAsGif').isBoolean().optional().run(request)
+    await body('options.sendMediaAsSticker').isBoolean().optional().run(request)
+    await body('options.sendMediaAsDocument').isBoolean().optional().run(request)
+    await body('options.caption').isString().optional().run(request)
+    await body('options.quotedMessageId').isString().optional().run(request)
+    await body('options.mentions').isArray().optional().run(request)
+    await body('options.sendSeen').isBoolean().optional().run(request)
+    await body('options.stickerName').isString().optional().run(request)
+    await body('options.stickerAuthor').isString().optional().run(request)
+    await body('options.stickerCategories').isArray().optional().run(request)
+
     Validator(request, response)
 }

--- a/tests/Services/Message/MediaUrlMessageCreator.test.ts
+++ b/tests/Services/Message/MediaUrlMessageCreator.test.ts
@@ -9,6 +9,6 @@ describe('Text message creator test', () => {
         await creator.create('123456789', 'https://www.google.com')
 
         expect(mockMessageMedia.fromUrl).toBeCalledWith('https://www.google.com', { unsafeMime: true })
-        expect(mockWhatsappClient.sendMessage).toBeCalledWith('123456789', true)
+        expect(mockWhatsappClient.sendMessage).toBeCalledWith('123456789', true, undefined)
     })
 })

--- a/tests/Services/Message/TextMessageCreator.test.ts
+++ b/tests/Services/Message/TextMessageCreator.test.ts
@@ -12,6 +12,6 @@ describe('Text message creator test', () => {
         const creator = new TextMessageCreator(mockWhatsapp)
         await creator.create('123456789', 'test message')
 
-        expect(mockWhatsappClient.sendMessage).toBeCalledWith('123456789', 'test message')
+        expect(mockWhatsappClient.sendMessage).toBeCalledWith('123456789', 'test message', undefined)
     })
 })

--- a/tests/http/controllers/ChatMessageController.test.ts
+++ b/tests/http/controllers/ChatMessageController.test.ts
@@ -62,6 +62,21 @@ jest.mock('../../../src/Services/Message/MessageDeleter', () => {
     })
 })
 
+const options = {
+    linkPreview: undefined,
+    sendAudioAsVoice: undefined,
+    sendVideoAsGif: undefined,
+    sendMediaAsSticker: undefined,
+    sendMediaAsDocument: undefined,
+    caption: undefined,
+    quotedMessageId: undefined,
+    mentions: undefined,
+    sendSeen: undefined,
+    stickerName: undefined,
+    stickerAuthor: undefined,
+    stickerCategories: undefined
+}
+
 describe('ChatMessageController', () => {
     afterEach(() => {
         jest.restoreAllMocks()
@@ -87,7 +102,25 @@ describe('ChatMessageController', () => {
             .expect(200, mockMessage.rawData)
 
         expect(mockTextSender).toBeCalledTimes(1)
-        expect(mockTextSender).toBeCalledWith('1234567890@c.us', 'Test')
+        expect(mockTextSender).toBeCalledWith('1234567890@c.us', 'Test', expect.any(Object))
+    })
+
+    it('send text message to chat with options', async () => {
+        mockTextSender.mockResolvedValue(mockMessage)
+
+        await request(testServer.app)
+            .post('/api/chats/1234567890/messages')
+            .send({
+                msg: 'Test',
+                options: {
+                    quotedMessageId: '1234567890',
+                    sendAudioAsVoice: true
+                }
+            })
+            .expect(200, mockMessage.rawData)
+
+        expect(mockTextSender).toBeCalledTimes(1)
+        expect(mockTextSender).toBeCalledWith('1234567890@c.us', 'Test', { ...options, quotedMessageId: '1234567890', sendAudioAsVoice: true })
     })
 
     it('send file message to chat', async () => {
@@ -99,7 +132,29 @@ describe('ChatMessageController', () => {
             .expect(200, mockMessage.rawData)
 
         expect(mockFileSender).toBeCalledTimes(1)
-        expect(mockFileSender).toBeCalledWith('1234567890@c.us', 'https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png')
+        expect(mockFileSender).toBeCalledWith('1234567890@c.us', 'https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png', expect.any(Object))
+    })
+
+    it('send file message to chat with options', async () => {
+        mockFileSender.mockResolvedValue(mockMessage)
+
+        await request(testServer.app)
+            .post('/api/chats/1234567890/messages')
+            .send({
+                url: 'https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png',
+                options: {
+                    quotedMessageId: '1234567890',
+                    sendAudioAsVoice: true
+                }
+            })
+            .expect(200, mockMessage.rawData)
+
+        expect(mockFileSender).toBeCalledTimes(1)
+        expect(mockFileSender).toBeCalledWith(
+            '1234567890@c.us',
+            'https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png',
+            { ...options, quotedMessageId: '1234567890', sendAudioAsVoice: true }
+        )
     })
 
     it('star a message', async () => {


### PR DESCRIPTION
Added [whatsapp-web.js](https://docs.wwebjs.dev/index.html) options in message sender controller

you can see the options in the official documentation [here](https://docs.wwebjs.dev/global.html#MessageSendOptions)

### Usage Example

`POST /api/chat/{id}/messages`


Request Body:
```json
{
    "utl": "https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png",
    "options": {
         "sendVideoAsGif" : true,
         "caption" : "Text of message"
    }
}
```
